### PR TITLE
Fixes CVE-2025-55182

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM node:alpine
+# Build stage
+FROM node:22-alpine3.21 AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . ./
+
+# Production stage
+FROM node:22-alpine3.21
 WORKDIR /app
 RUN apk add --no-cache chromium
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-# against cache of package.json
-COPY package.json ./
-RUN npm i
-COPY . ./
+COPY --from=builder /app ./
 CMD ["node", "--import", "tsx", "src/Main.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
         "jimp": "^1.6.0",
         "liquidjs": "^10.21.1",
         "puppeteer": "^24.9.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "react": "^19.1.2",
+        "react-dom": "^19.1.2",
         "tsx": "^4.19.4"
       },
       "devDependencies": {
@@ -25,6 +25,9 @@
         "typescript": "^5.8.3",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3232,24 +3235,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/readable-stream": {
@@ -3400,9 +3403,9 @@
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "jimp": "^1.6.0",
     "liquidjs": "^10.21.1",
     "puppeteer": "^24.9.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "^19.1.2",
+    "react-dom": "^19.1.2",
     "tsx": "^4.19.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "byos_node_lite",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "start": "tsx --env-file=.env.local src/Main.ts",
     "watch": "tsx watch --env-file=.env.local src/Main.ts",


### PR DESCRIPTION
- Use multi-stage Docker build for smaller image size
- Pin Alpine to node:22-alpine3.21 for reproducible builds
- Use npm ci with package-lock.json for deterministic installs
- Add engines field requiring Node.js >=20
- Fixes for CVE-2025-55182